### PR TITLE
デフォルトで実行環境のクレデンシャルを取得するよう変更

### DIFF
--- a/azfs/core.py
+++ b/azfs/core.py
@@ -38,11 +38,13 @@ class AzFileClient:
 
     def __init__(
             self,
-            credential: Union[str, DefaultAzureCredential]):
+            credential: Union[str, DefaultAzureCredential, None] = None):
         """
 
         :param credential: if string, Blob Storage -> Access Keys -> Key
         """
+        if credential is None:
+            credential = DefaultAzureCredential()
         self.credential = credential
 
         # 各種ストレージのclient


### PR DESCRIPTION
AzureのManagedIDをサポートしているサービス（ex. Azure Functions）で認証情報の
入力を省略できるよう変更しました。